### PR TITLE
Correct a small error in the Development README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Development
 ---------------------
 The development server will start on [localhost:3000](http://localhost:3000) by default. It automatically detects file changes with [nodemon](https://www.npmjs.com/package/nodemon), and transpiles TypeScript on the fly using [ts-node](https://www.npmjs.com/package/ts-node).
 
+*Note*: Make sure to edit `nodemon.json` so that the `exec` command points to the absolute path of the Connect App on your system.
+
 ```sh-session
-$ npm start:dev
+$ npm run start:dev
 ```
 
 


### PR DESCRIPTION
Edits the setup instructions so that:

1. There's now a note mentioning that you need to edit `nodemon.json` before you can successfully hook up an app.
2. `npm start:dev` needs to be `npm run start:dev` because the former errors out when Node thinks you're mistakenly trying to invoke the `npm start` command.